### PR TITLE
fixing issue with interface api not being met

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -109,6 +109,10 @@ func (h VitessHandler) HandleStmtExecute(context interface{}, query string, args
 	return nil, nil
 }
 
+func (h VitessHandler) HandleStmtClose(context interface{}) error {
+	return nil
+}
+
 //handle COM_INIT_DB command, you can check whether the dbName is valid, or other.
 func (h VitessHandler) UseDB(dbName string) error {
 	return nil


### PR DESCRIPTION
received the following error message when trying to use your project. 

$ go run cmd/main.go --vitess_server=x.x.x.x:15991 --keyspace=yyy --shard=0
# command-line-arguments

cmd/main.go:60: cannot use vitessproxy.VitessHandler literal (type vitessproxy.VitessHandler) as type server.Handler in argument to server.NewConn:
    vitessproxy.VitessHandler does not implement server.Handler (missing HandleStmtClose method)
